### PR TITLE
Rewrite rsqrt with Arm64/NEON counterpart

### DIFF
--- a/src/svd/Singular_Value_Decomposition_Preamble.hpp
+++ b/src/svd/Singular_Value_Decomposition_Preamble.hpp
@@ -52,7 +52,11 @@
 #endif
 
 #ifdef USE_NEON_IMPLEMENTATION
+#if defined(__aarch64__)
+#include <arm_neon.h>
+#else // Arm32 fallback
 #include "sse2neon.h"
+#endif
 #endif
 
 #ifdef USE_SCALAR_IMPLEMENTATION
@@ -66,6 +70,9 @@
 // Changed to inline
 inline float rsqrt(const float f)
 {
+#if defined(__aarch64__)
+    return vrsqrteq_f32(vdupq_n_f32(f))[0];
+#endif
     float buf[4];
     buf[0]=f;
     __m128 v=_mm_loadu_ps(buf);


### PR DESCRIPTION
rsqrt is the operation for floating reciprocal square root estimate. In Arm64, we can implement it with NEON intrinsics. Since Armv8.2, instruction [FRSQRTE](https://developer.arm.com/documentation/dui0801/k/A64-SIMD-Vector-Instructions/FRSQRTE--vector-) is provided to calculate an approximate square root for each vector element in the source SIMD and FP register.

With -O3, generated assembly on Apple Silicon M1:

[original]
```
        fsqrt   s0, s0
        fmov    s1, #1.00000000
        fdiv    s0, s1, s0
```

[neon]
```
        dup.4s  v0, v0[0]
        frsqrte.4s      v0, v0
```